### PR TITLE
Change wso2/wso2base base image from :latest to :16.04

### DIFF
--- a/wso2base/Dockerfile
+++ b/wso2base/Dockerfile
@@ -16,7 +16,7 @@
 
 # ------------------------------------------------------------------------
 
-FROM ubuntu:latest
+FROM ubuntu:16.04
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/wso2base/build.sh
+++ b/wso2base/build.sh
@@ -23,4 +23,4 @@ self_path=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "${self_path}/../scripts/base.sh"
 
 echoBold "Building docker base image..."
-docker build -t wso2/wso2base ${self_path}
+docker build -t wso2/wso2base:ubuntu-16.04 ${self_path}

--- a/wso2base/build.sh
+++ b/wso2base/build.sh
@@ -20,7 +20,7 @@
 set -e
 
 self_path=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-source "${self_path}/../common/scripts/base.sh"
+source "${self_path}/../scripts/base.sh"
 
 echoBold "Building docker base image..."
 docker build -t wso2/wso2base ${self_path}


### PR DESCRIPTION
## Purpose
This PR changes the `wso2/wso2base` image's base image version from `ubuntu:latest` to `ubuntu:16.04`. Some irregular behavior has been observed when trying to install packages on top of the older `wso2/wso2base` image.

## Goals
Changing the Ubuntu version to a fixed `16.04` version has been tested to solve the above-mentioned issue.

## Approach
Changing the tag in the `FROM` directive in the Dockerfile

## User stories
`wso2/wso2base` image building has to be redone to build the new images. 

## Release note
~~After this change, the new image `wso2/wso2base:ubuntu-16.04` has to be pushed to `wso2` repository in the public [Docker Hub](https://hub.docker.com/r/wso2/wso2base/tags/)~~ This is done now. 

## Documentation
No impact

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
https://github.com/wso2/docker-ei/pull/11

## Migrations (if applicable)
N/A

## Test environment
Ubuntu 16.04.3 LTS
Docker version: 17.05.0-ce Built: Thu May  4 22:10:54 2017
 
## Learning
N/A